### PR TITLE
(doc) Corrected command line

### DIFF
--- a/prepare-vms/azure/README.md
+++ b/prepare-vms/azure/README.md
@@ -13,7 +13,7 @@ packer build
 cd terraform
 terraform init
 terraform plan
-terraform apply -var 'count={ windows=3 }'
+terraform apply -var 'count=3'
 ```
 
 ## Destroy


### PR DESCRIPTION
- Using what was suggested, results in:
`Error: variable count should be type string, got map`